### PR TITLE
Removed Additional Loot Group for Geo Mobs

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_force_kliknik.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_force_kliknik.lua
@@ -35,12 +35,6 @@ enhanced_force_kliknik = Creature:new {
 			},
 			lootChance = 2880000
 		},
-		{
-			groups = {
-				{group = "clothing_attachments", chance = 1000000},
-				{group = "armor_attachments", chance = 1000000},
-			},
-		}
 	},
 	weapons = {"creature_spit_heavy_flame"},
 	conversationTemplate = "",

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_gaping_spider.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_gaping_spider.lua
@@ -33,12 +33,6 @@ enhanced_gaping_spider = Creature:new {
 			groups = {
 				{group = "fire_breathing_spider", chance = 10000000}
 			}
-		},
-		{
-			groups = {
-				{group = "clothing_attachments", chance = 1000000},
-				{group = "armor_attachments", chance = 1000000},
-			},
 		}
 	},
 	weapons = {"creature_spit_heavy_flame"},

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_kliknik.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_kliknik.lua
@@ -34,12 +34,6 @@ enhanced_kliknik = Creature:new {
 			},
 			lootChance = 5000000
 		},
-		{
-			groups = {
-				{group = "clothing_attachments", chance = 1000000},
-				{group = "armor_attachments", chance = 1000000},
-			},
-		}
 	},
 	weapons = {"creature_spit_heavy_flame"},
 	conversationTemplate = "",

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_kwi.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/geonosian_bio_lab/enhanced_kwi.lua
@@ -34,12 +34,6 @@ enhanced_kwi = Creature:new {
 			},
 			lootChance = 5000000
 		},
-		{
-			groups = {
-				{group = "clothing_attachments", chance = 1000000},
-				{group = "armor_attachments", chance = 1000000},
-			},
-		}
 	},
 	weapons = {},
 	conversationTemplate = "",


### PR DESCRIPTION
Removed the additional Attachments separate Loot Group, as it seems to be affecting the drops for these mobs. We can add them back into their overall loot group and adjust weights if needed.